### PR TITLE
Assistant checkpoint: Implement automatic browser password protection…

### DIFF
--- a/SAFP.core/BrowserFileManager.cs
+++ b/SAFP.core/BrowserFileManager.cs
@@ -555,5 +555,14 @@ namespace SAFP.Core
             messages.Add($"Securely deleted {deletedCount} browser files for security.");
             return (deletedCount > 0, messages);
         }
+
+        /// <summary>
+        /// Determines if browser files should be restored at startup.
+        /// This happens when we have a backup but no browser files currently exist.
+        /// </summary>
+        public bool ShouldRestoreAtStartup()
+        {
+            return DoesBackupExist() && !DoBrowserFilesExist();
+        }
     }
 }

--- a/SAFP.wpf/MainWindow.xaml.cs
+++ b/SAFP.wpf/MainWindow.xaml.cs
@@ -47,9 +47,34 @@ namespace SAFP.Wpf
             }
             catch (Exception ex)
             {
-                 Debug.WriteLine($"[MainWindow] FATAL ERROR in Constructor: {ex}");
-                 MessageBox.Show($"Fatal error initializing main window: {ex.Message}", "Initialization Error", MessageBoxButton.OK, MessageBoxImage.Error);
-                 Application.Current?.Shutdown(1);
+                Debug.WriteLine($"[MainWindow] ERROR during construction: {ex.Message}");
+                MessageBox.Show($"Failed to initialize main window: {ex.Message}", "Initialization Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                throw; // Re-throw to let App.xaml.cs handle it
+            }
+        }
+
+        private async void MainWindow_Closing(object? sender, CancelEventArgs e)
+        {
+            Debug.WriteLine("[MainWindow] MainWindow_Closing called.");
+
+            // Check if user wants to exit
+            if (!_viewModel.CanExitApplication())
+            {
+                e.Cancel = true;
+                return;
+            }
+
+            // Perform browser cleanup
+            try
+            {
+                var browserManager = new BrowserFileManager();
+                Debug.WriteLine("[MainWindow] Securely deleting browser files on window close...");
+                var (deleteSuccess, deleteMessages) = await browserManager.SecureDeleteAllBrowserFilesAsync();
+                Debug.WriteLine($"[MainWindow] Browser file deletion completed. Success: {deleteSuccess}");
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[MainWindow] Error during browser file cleanup: {ex.Message}");
             }
         }
 


### PR DESCRIPTION
… system

Assistant generated file changes:
- SAFP.wpf/App.xaml.cs: Add automatic browser backup on first startup, Initialize browser manager and handle automatic backup, Add automatic browser backup for first-time users, Perform automatic browser backup and secure delete after successful login, Add using statement for BrowserFileManager, Add secure browser file deletion on app exit, Use ShouldRestoreAtStartup for better logic, Improve automatic backup message
- SAFP.wpf/MainWindow.xaml.cs: Add MainWindow closing event handler Add MainWindow closing event handler
- SAFP.core/BrowserFileManager.cs: Add method to check if startup restore is needed

---

User prompt:

I want you update the code in this project , when the user start the APP for the very first time, the App should automaticly make a Backup of the Passwords stored in the Browsers, then delete the Origiin files in a way that dosen't make it possiable for hackers to restore the origin files, then make a restore from the encrypted backup file , when ever the app is close the origin files should be deleted. the Browser password should only be avaleable in the Browser if the APP was running . do that without removin any functiunality. and do it with the same Technologies

Replit-Commit-Author: Assistant
Replit-Commit-Session-Id: 1d40f769-4d25-4b75-810c-c8fc46e33b82